### PR TITLE
[BUGFIX] Add a label on the button to open and close menu barre

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -64,6 +64,7 @@ export default function Header() {
             whileTap={{ scale: 0.95 }}
             onClick={() => setIsOpen(!isOpen)}
             className="md:hidden p-2"
+            aria-label={!isOpen ? 'Open menu' : 'Close menu'}
           >
             <div className="w-6 h-0.5 bg-gray-600 dark:bg-gray-300 mb-1.5" />
             <div className="w-6 h-0.5 bg-gray-600 dark:bg-gray-300 mb-1.5" />


### PR DESCRIPTION
This pull request includes a small but important accessibility improvement to the `Header` component in `src/components/Header.tsx`. The change adds an `aria-label` attribute to the button that toggles the menu, improving accessibility for screen reader users.

* [`src/components/Header.tsx`](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fR67): Added `aria-label` attribute to the menu toggle button to indicate whether the menu is open or closed.